### PR TITLE
Fix/makefile absolute paths

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -61,13 +61,13 @@ function( create_library_makefile targetName )
 
     set(DMOD_RELATIVE_HEADER_PATHS "")
     foreach(HEADER_PATH ${DMOD_INC_DIRS})
-        # Sprawdź czy ścieżka jest bezwzględna
+        # Check if path is absolute
         if(IS_ABSOLUTE "${HEADER_PATH}")
-            # Najpierw spróbuj zamienić na zmienne dmod
+            # First try to replace with dmod variables
             string(REPLACE "${DMOD_BUILD_DIR}" "$(DMOD_BUILD_DIR)" HEADER_PATH "${HEADER_PATH}")
             string(REPLACE "${DMOD_DIR}" "$(DMOD_DIR)" HEADER_PATH "${HEADER_PATH}")
             
-            # Jeśli nadal jest bezwzględna, konwertuj na względną względem CMAKE_CURRENT_SOURCE_DIR
+            # If still absolute, convert to relative path relative to CMAKE_CURRENT_SOURCE_DIR
             if(IS_ABSOLUTE "${HEADER_PATH}")
                 file(RELATIVE_PATH RELATIVE_HEADER_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${HEADER_PATH}")
                 set(HEADER_PATH "${RELATIVE_HEADER_PATH}")
@@ -86,16 +86,16 @@ endfunction()
 
 
 function(to_snake_case INPUT_STRING OUTPUT_VARIABLE)
-    # Zamiana myślników na podkreślenia
+    # Replace hyphens with underscores
     string(REPLACE "-" "_" INTERMEDIATE_STRING "${INPUT_STRING}")
     
-    # Zamiana spacji na podkreślenia
+    # Replace spaces with underscores
     string(REPLACE " " "_" INTERMEDIATE_STRING "${INTERMEDIATE_STRING}")
     
-    # Konwersja na małe litery
+    # Convert to lowercase
     string(TOLOWER "${INTERMEDIATE_STRING}" SNAKE_CASE_STRING)
     
-    # Przypisanie wyniku do zmiennej wyjściowej
+    # Set the result to the output variable
     set(${OUTPUT_VARIABLE} "${SNAKE_CASE_STRING}" PARENT_SCOPE)
 endfunction()
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -61,8 +61,19 @@ function( create_library_makefile targetName )
 
     set(DMOD_RELATIVE_HEADER_PATHS "")
     foreach(HEADER_PATH ${DMOD_INC_DIRS})
-        string(REPLACE "${DMOD_BUILD_DIR}" "$(DMOD_BUILD_DIR)" HEADER_PATH "${HEADER_PATH}")
-        string(REPLACE "${DMOD_DIR}" "$(DMOD_DIR)" HEADER_PATH "${HEADER_PATH}")
+        # Sprawdź czy ścieżka jest bezwzględna
+        if(IS_ABSOLUTE "${HEADER_PATH}")
+            # Najpierw spróbuj zamienić na zmienne dmod
+            string(REPLACE "${DMOD_BUILD_DIR}" "$(DMOD_BUILD_DIR)" HEADER_PATH "${HEADER_PATH}")
+            string(REPLACE "${DMOD_DIR}" "$(DMOD_DIR)" HEADER_PATH "${HEADER_PATH}")
+            
+            # Jeśli nadal jest bezwzględna, konwertuj na względną względem CMAKE_CURRENT_SOURCE_DIR
+            if(IS_ABSOLUTE "${HEADER_PATH}")
+                file(RELATIVE_PATH RELATIVE_HEADER_PATH "${CMAKE_CURRENT_SOURCE_DIR}" "${HEADER_PATH}")
+                set(HEADER_PATH "${RELATIVE_HEADER_PATH}")
+            endif()
+        endif()
+        
         message(STATUS "HEADER_PATH: ${HEADER_PATH}")
         list(APPEND DMOD_RELATIVE_HEADER_PATHS "${HEADER_PATH}")
     endforeach()


### PR DESCRIPTION
This pull request updates the `scripts/CMakeLists.txt` file with improvements to path handling and code documentation. The most significant changes are the enhancement of how header paths are processed to ensure they are relative, and the translation of comments in the `to_snake_case` function from Polish to English for better readability.

**Path handling improvements:**

* Updated the logic in `create_library_makefile` to ensure that all header paths in `DMOD_INC_DIRS` are converted to relative paths if they are absolute, improving portability and build reliability. This includes replacing known variables and, if necessary, converting to a path relative to `CMAKE_CURRENT_SOURCE_DIR`.

**Documentation and readability:**

* Translated all comments in the `to_snake_case` function from Polish to English, making the codebase more accessible to non-Polish speakers and improving maintainability.