### PR TITLE
Added MemoryExtended versions to track the memory allocations

### DIFF
--- a/examples/module/application/main.c
+++ b/examples/module/application/main.c
@@ -50,5 +50,12 @@ int main(int argc, char** argv)
 
     _print("Hello from main using _print");
 
+    void* mem = Dmod_Malloc(128);
+    if (mem != NULL)
+    {
+        Dmod_Printf("Allocated 128 bytes at %p\n", mem);
+        Dmod_Free(mem);
+    }
+
     return 0;
 }

--- a/inc/dmod_sal.h
+++ b/inc/dmod_sal.h
@@ -64,11 +64,23 @@ extern "C" {
  * 
  * @addtogroup DMOD_SAL_MEM
  * @{
- */ 
-DMOD_BUILTIN_API(Dmod, 1.0, void*,  _Malloc ,           ( size_t Size )                     );
-DMOD_BUILTIN_API(Dmod, 1.0, void*,  _Realloc,           ( void* Ptr, size_t Size )          );
-DMOD_BUILTIN_API(Dmod, 1.0, void ,  _Free   ,           ( void* Ptr )                       );
-DMOD_BUILTIN_API(Dmod, 1.0, void*,  _AlignedMalloc,     ( size_t Size, size_t Alignment )   );
+ */
+#if defined(DMOD_MODULE_NAME)
+#   define Dmod_Malloc(Size)                        Dmod_MallocEx(Size, DMOD_MODULE_NAME)
+#   define Dmod_Realloc(Ptr, Size)                  Dmod_ReallocEx(Ptr, Size, DMOD_MODULE_NAME)
+#   define Dmod_AlignedMalloc(Size, Alignment)      Dmod_AlignedMallocEx(Size, Alignment, DMOD_MODULE_NAME)
+#   define Dmod_Free(Ptr)                           Dmod_FreeEx(Ptr, false)
+#else 
+    DMOD_BUILTIN_API(Dmod, 1.0, void*,  _Malloc ,           ( size_t Size )                     );
+    DMOD_BUILTIN_API(Dmod, 1.0, void*,  _Realloc,           ( void* Ptr, size_t Size )          );
+    DMOD_BUILTIN_API(Dmod, 1.0, void ,  _Free   ,           ( void* Ptr )                       );
+    DMOD_BUILTIN_API(Dmod, 1.0, void*,  _AlignedMalloc,     ( size_t Size, size_t Alignment )   );
+#endif
+DMOD_BUILTIN_API(Dmod, 1.0, void*,  _MallocEx,          ( size_t Size, const char* ModuleName ) );
+DMOD_BUILTIN_API(Dmod, 1.0, void*,  _ReallocEx,         ( void* Ptr, size_t Size, const char* ModuleName ) );
+DMOD_BUILTIN_API(Dmod, 1.0, void ,  _FreeEx ,           ( void* Ptr, bool Concatenate ) );
+DMOD_BUILTIN_API(Dmod, 1.0, void*,  _AlignedMallocEx,   ( size_t Size, size_t Alignment, const char* ModuleName ) );
+DMOD_BUILTIN_API(Dmod, 1.0, void,   _FreeModule,        ( const char* ModuleName )          );
 DMOD_BUILTIN_API(Dmod, 1.0, size_t, _ReadMemory,        ( uintptr_t Address, void* Buffer, size_t Size ) );
 DMOD_BUILTIN_API(Dmod, 1.0, size_t, _WriteMemory,       ( uintptr_t Address, const void* Buffer, size_t Size ) );
 //! @}

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -178,6 +178,8 @@ function(dmod_create_module moduleName version moduleType)
         PUBLIC
             DMOD_${moduleName}
             DMOD_MODE="DMOD_MODULE"
+            DMOD_MODULE_NAME="${moduleName}"
+            DMOD_MODULE_VERSION="${version}"
             DMOD_MODULE=1
             DMOD_SYSTEM=0
         )

--- a/scripts/api.h.in
+++ b/scripts/api.h.in
@@ -24,8 +24,12 @@
     extern const char* const DMOD_MAKE_DIF_SIG_NAME(@DMOD_MODULE_NAME_SNAKE_CASE@, NAME);
 #  define dmod_@DMOD_MODULE_NAME_SNAKE_CASE@_dif_api_declaration(VERSION, IMPL_MODULE, RET, NAME, PARAMS)  \
             DMOD_DIF_API_DECLARATION(@DMOD_MODULE_NAME@, IMPL_MODULE, VERSION, RET, NAME, PARAMS)
-#   define DMOD_MODULE_NAME        "@DMOD_MODULE_NAME@"
-#   define DMOD_MODULE_VERSION     "@DMOD_MODULE_VERSION@"
+#   ifndef DMOD_MODULE_NAME
+#       define DMOD_MODULE_NAME        "@DMOD_MODULE_NAME@"
+#   endif
+#   ifndef DMOD_MODULE_VERSION
+#       define DMOD_MODULE_VERSION     "@DMOD_MODULE_VERSION@"
+#   endif
 #   define DMOD_AUTHOR_NAME        "@DMOD_AUTHOR_NAME@"
 #   define DMOD_STACK_SIZE         @DMOD_STACK_SIZE@
 #   define DMOD_PRIORITY           @DMOD_PRIORITY@

--- a/scripts/dmf.mk
+++ b/scripts/dmf.mk
@@ -75,6 +75,8 @@ DMOD_CSOURCES	    += $(DMOD_MODULE_HEADER_SOURCE_FILE_PATH)
 DMOD_MAL_DEFS       += $(foreach impl,$(DMOD_MAL_IMPLS),DMOD_MAL_$(impl))
 DMOD_DIF_DEFS       += $(foreach impl,$(DMOD_DIF_IMPLS),DMOD_DIF_$(impl))
 DMOD_DEFINITIONS    += DMOD_${DMOD_MODULE_NAME} \
+					   DMOD_MODULE_NAME=\"$(DMOD_MODULE_NAME)\" \
+					   DMOD_MODULE_VERSION=\"$(DMOD_MODULE_VERSION)\" \
             		   DMOD_MODULE=1 \
             		   DMOD_SYSTEM=0 \
 					   $(DMOD_MAL_DEFS) \

--- a/src/system/if/dmod_if_mem.c
+++ b/src/system/if/dmod_if_mem.c
@@ -65,6 +65,7 @@ DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _Malloc, ( size_t Size ))
  */
 DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _MallocEx, ( size_t Size, const char* ModuleName ))
 {
+    DMOD_LOG_VERBOSE("Allocating %zu bytes for module: %s\n", Size, ModuleName ? ModuleName : "NULL");
 #if DMOD_USE_ALIGNED_MALLOC_MOCK
     return Dmod_AlignedMalloc(Size, sizeof(void*));
 #elif DMOD_USE_STDLIB

--- a/src/system/if/dmod_if_mem.c
+++ b/src/system/if/dmod_if_mem.c
@@ -52,6 +52,19 @@
  */
 DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _Malloc, ( size_t Size ))
 {
+    return Dmod_MallocEx(Size, NULL);
+}
+
+/**
+ * @brief Allocate memory
+ * 
+ * @param Size Size of memory to allocate
+ * @param ModuleName Name of the module requesting memory
+ * 
+ * @return Pointer to allocated memory
+ */
+DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _MallocEx, ( size_t Size, const char* ModuleName ))
+{
 #if DMOD_USE_ALIGNED_MALLOC_MOCK
     return Dmod_AlignedMalloc(Size, sizeof(void*));
 #elif DMOD_USE_STDLIB
@@ -71,6 +84,20 @@ DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _Malloc, ( size_t Size ))
  * @return Pointer to reallocated memory
  */
 DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _Realloc, ( void* Ptr, size_t Size ))
+{
+    return Dmod_ReallocEx(Ptr, Size, NULL);
+}
+
+/**
+ * @brief Reallocate memory
+ * 
+ * @param Ptr Pointer to memory to reallocate
+ * @param Size Size of memory to allocate
+ * @param ModuleName Name of the module requesting memory
+ * 
+ * @return Pointer to reallocated memory
+ */
+DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _ReallocEx, ( void* Ptr, size_t Size, const char* ModuleName ))
 {
 #if DMOD_USE_STDLIB && DMOD_USE_REALLOC
     return realloc(Ptr, Size);
@@ -96,6 +123,21 @@ DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _Realloc, ( void* Ptr, size_t 
  * @note Optional - set to NULL if not supported
  */
 DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _AlignedMalloc, ( size_t Size, size_t Alignment ))
+{
+    return Dmod_AlignedMallocEx(Size, Alignment, NULL);
+}
+
+/**
+ * @brief Allocate aligned memory
+ * 
+ * @param Size Size of memory to allocate
+ * @param Alignment Alignment of memory
+ * 
+ * @return Pointer to allocated memory
+ * 
+ * @note Optional - set to NULL if not supported
+ */
+DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _AlignedMallocEx, ( size_t Size, size_t Alignment, const char* ModuleName ))
 {
     void* mem = NULL;
     size_t pagesize = Alignment;
@@ -144,12 +186,23 @@ DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void*, _AlignedMalloc, ( size_t Size,
     return mem;
 }
 
+
 /**
  * @brief Free memory
  * 
  * @param ptr Pointer to memory to free
  */
 DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void, _Free, ( void* ptr ))
+{
+    Dmod_FreeEx(ptr, false);
+}
+
+/**
+ * @brief Free memory
+ * 
+ * @param ptr Pointer to memory to free
+ */
+DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void, _FreeEx, ( void* ptr, const bool concatenate ))
 {
 #if DMOD_USE_ALIGNED_MALLOC_MOCK
     #if !DMOD_USE_STDLIB
@@ -162,4 +215,15 @@ DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void, _Free, ( void* ptr ))
 #else 
     DMOD_LOG_ERROR("Dmod_Free interface not implemented");
 #endif
+}
+
+/**
+ * @brief Free all memory allocated by a module
+ * 
+ * @param ModuleName Name of the module
+ */
+DMOD_INPUT_WEAK_API_DECLARATION(Dmod, 1.0, void, _FreeModule, ( const char* ModuleName ))
+{
+    (void)ModuleName;
+    DMOD_LOG_WARN("Dmod_FreeModule interface not implemented");
 }

--- a/src/system/private/dmod_ctx.c
+++ b/src/system/private/dmod_ctx.c
@@ -90,6 +90,8 @@ void Dmod_Context_Delete( Dmod_Context_t* Context )
     {
         return;
     }
+    char moduleName[DMOD_MAX_MODULE_NAME_LENGTH] = {0};
+    strncpy( moduleName, Dmod_Context_GetModuleName( Context ), sizeof(moduleName)-1 );
 
     Dmod_Mutex_Delete( Context->Mutex );
     if( Context->Data != NULL )
@@ -97,6 +99,7 @@ void Dmod_Context_Delete( Dmod_Context_t* Context )
         Dmod_Free( Context->Data );
     }
     Dmod_Free( Context );
+    Dmod_FreeModule( moduleName );
 }
 
 /**


### PR DESCRIPTION
This pull request introduces module-aware memory management to the DMOD system, allowing modules to specify their names and versions during memory operations. The changes add new APIs for allocating, reallocating, and freeing memory with module context, update build scripts to propagate module information, and refactor existing memory interface implementations to support these features.

### Memory Management API Enhancements

* Added new APIs: `Dmod_MallocEx`, `Dmod_ReallocEx`, `Dmod_AlignedMallocEx`, `Dmod_FreeEx`, and `Dmod_FreeModule` to allow memory operations to be associated with a specific module name. The standard APIs now delegate to these when `DMOD_MODULE_NAME` is defined. (`inc/dmod_sal.h`, [inc/dmod_sal.hR68-R83](diffhunk://#diff-7a324c0c8b37c1e04a31b8b847db8d5dceef3875274ec43390629c94ed370eb1R68-R83))
* Implemented corresponding weak interface functions in `dmod_if_mem.c`, which log the module name and handle memory operations with module context. (`src/system/if/dmod_if_mem.c`, [[1]](diffhunk://#diff-e15edce55423f73fcc8e948e884c16be15ea669cc9ff8a0f0029fcb2f54435f5R55-R68) [[2]](diffhunk://#diff-e15edce55423f73fcc8e948e884c16be15ea669cc9ff8a0f0029fcb2f54435f5R88-R101) [[3]](diffhunk://#diff-e15edce55423f73fcc8e948e884c16be15ea669cc9ff8a0f0029fcb2f54435f5R127-R141) [[4]](diffhunk://#diff-e15edce55423f73fcc8e948e884c16be15ea669cc9ff8a0f0029fcb2f54435f5R190-R206) [[5]](diffhunk://#diff-e15edce55423f73fcc8e948e884c16be15ea669cc9ff8a0f0029fcb2f54435f5R220-R230)

### Build System and Module Metadata

* Updated CMake and Make scripts to define `DMOD_MODULE_NAME` and `DMOD_MODULE_VERSION` as compile-time definitions, ensuring module metadata is available throughout the build and in the code. (`scripts/CMakeLists.txt`, [[1]](diffhunk://#diff-1fa114fd37754ac397e510000838b3f7bc8cbe1c517d67e680dd4644cfc99c21R181-R182); `scripts/dmf.mk`, [[2]](diffhunk://#diff-a2a9dde37373d38aee4628c152ba6680ebef2e6f3c9a36f4d4881a3e06efcde2R78-R79)
* Modified `api.h.in` to set default values for `DMOD_MODULE_NAME` and `DMOD_MODULE_VERSION` if not already defined, improving portability and consistency of module metadata. (`scripts/api.h.in`, [scripts/api.h.inR27-R32](diffhunk://#diff-f69ecaf63031f8f27374fff587c2b288197a2bba49e64433114b809bea5a209eR27-R32))

### Example Usage

* Updated the main application example to demonstrate module-aware memory allocation and deallocation using the new APIs. (`examples/module/application/main.c`, [examples/module/application/main.cR53-R59](diffhunk://#diff-3c1d4cc4f583a9c615319eba8689702595c348f287f2d5254b103bea922fcc30R53-R59))